### PR TITLE
Added during_move and after_move settings

### DIFF
--- a/repeatable-fields.js
+++ b/repeatable-fields.js
@@ -21,6 +21,9 @@
 			after_add: after_add,
 			before_remove: null,
 			after_remove: null,
+			after_move: null,
+	                during_move: null,
+        	   	after_move: null
 		}
 
 		var settings = $.extend(default_settings, custom_settings);
@@ -82,7 +85,9 @@
 				if(settings.is_sortable == true && typeof $.ui !== 'undefined' && typeof $.ui.sortable !== 'undefined') {
 					$(wrapper).find(settings.container).sortable({
 						handle: settings.move,
-						row: $(settings.row, '>')
+						row: $(settings.row, '>'),
+			                        sort: settings.during_move,						
+						stop: settings.after_move
 					});
 				}
 			});


### PR DESCRIPTION
Being able to call a function during a move and after a move was needed for me, so I wanted to contribute an update.  This could be used for instance when sorting rows and showing a row number.  When moving the rows during sort, the row numbers could temporarily hide, and when sorting is finished, reappear with the new sorting.
