### PR TITLE
Add data attribute based templating and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,26 @@ The functionality that is provided by this plugin can also be referred to as:
 * Dynamic Rows plugin
 * Add Remove Rows Plugin
 
+## How it works
+
+All plugin elements must be a child of the specified wrapper element.
+
+This plugin will repeat the specified template row by appending a copy to the specified container element. All rows (including the template row) must be a child of the container element.
+
+When the specified add element is clicked a new row is generated from the template row. All attributes on the template row will be copied to the newly generated row, replacing the specified `row_count_placeholder` (by default this is: "{{row-count-placeholder}}") with the row's index (zero based). By default, all input values (e.g. inputs|textareas|selects) are reset, but this can be turned off by setting the reset_inputs option to false.
+
+If you specify the row_count_placeholder in the template row's attributes, they will be replaced with any new rows' index when it is added, but will not update if the row is moved to another position; if you want the repeated rows' count placeholder to update when the row is moved you will need to use the data attribute based template values on the template row. The default prefix to all template data attributes is set by the `data_prefix` option (default: "template"), and then specify the attribute name to be templated after the prefix, separated by a hyphen.
+e.g. to template the `name` attribute of an input, the data attribute name would be: `data-template-name`.
+
+If an attribute and a data template attribute are both set for the same attribute on an element within the template row, the data template attribute is used instead of the regular attribute.
+
+If the `minimum` option is set, then the first minimum number of rows are created (if not already existig) and then cannot be removed (their remove elements are disabled).
+
 ## Requirements
 
 This plugin requires [jQuery](http://jquery.com/) and [jQuery UI Sortable](https://jqueryui.com/sortable/).
 
-### Example
+### Simple Example
 
 #### HTML
 
@@ -55,6 +70,41 @@ This plugin requires [jQuery](http://jquery.com/) and [jQuery UI Sortable](https
     	});
     });
 
+### Data Attribute Template Example
+
+#### HTML
+
+    <div class="repeat">
+        <table class="wrapper" width="100%">
+            <thead>
+                <tr>
+                    <td width="10%" colspan="4"><span class="add">Add</span></td>
+                </tr>
+            </thead>
+            <tbody class="container">
+            <tr class="template row">
+                <td width="10%"><span class="move">Move</span></td>
+        
+                <td width="10%">An Input Field</td>
+                
+                <td width="70%">
+                    <input type="text" data-template-name="an-input-field[{{row-count-placeholder}}]" />
+                </td>
+                
+                <td width="10%"><span class="remove">Remove</span></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+#### JavaScript
+
+    jQuery(function() {
+        jQuery('.repeat').each(function() {
+            jQuery(this).repeatable_fields();
+        });
+    });
+
 ## Options
 
 ```
@@ -65,11 +115,16 @@ add: '.add',
 remove: '.remove',
 move: '.move',
 template: '.template',
+minimum: 0,
+data_prefix: "template",
 before_add: null,
 after_add: after_add,
 before_remove: null,
 after_remove: null,
+is_sortable: true,
 sortable_options: null,
+reset_inputs: true,
+row_count_placeholder: "{{row-count-placeholder}}",
 ```
 
 <dl>
@@ -94,6 +149,12 @@ sortable_options: null,
 <dt>template</dt>
 <dd>Specifies an element within the container which acts as a row template.</dd>
 
+<dt>minimum</dt>
+<dd>Specifies how many rows must be present as a minimum.</dd>
+
+<dt>data_prefix</dt>
+<dd>Specifies the prefix used in a data attribute template value.</dd>
+
 <dt>before_add</dt>
 <dd>Specifies a function to run before a row is added</dd>
 
@@ -106,6 +167,18 @@ sortable_options: null,
 <dt>after_remove</dt>
 <dd>Specifies a function to run after a row is removed</dd>
 
+<dt>is_sortable</dt>
+<dd>Specifies whether to allow moving/reordering rows or not.</dd>
+</dl>
+
 <dt>sortable_options</dt>
 <dd>Specifies an object that can contain Options, Methods and Events which are passed to jQuery UI Sortable</dd>
+</dl>
+
+<dt>reset_inputs</dt>
+<dd>Specifies the whether to reset/clear all the input/textarea/select values from the template row or not.</dd>
+</dl>
+
+<dt>row_count_placeholder</dt>
+<dd>Specifies the placeholder value to be replaced with the row count (zero based) within all attributes of a template row.</dd>
 </dl>

--- a/repeatable-fields.js
+++ b/repeatable-fields.js
@@ -80,7 +80,7 @@
 					var row = $(this).parents(settings.row).first();
 
 					if(typeof settings.before_remove === 'function') {
-						settings.before_remove(container, row);
+					    settings.before_remove(container, row);
 					}
 
 					row.remove();
@@ -109,6 +109,16 @@
 
 					$(wrapper).find(settings.container).sortable(sortable_options);
 				}
+
+
+				var rows = $(container).children(settings.row).filter(function () {
+				        return !jQuery(this).hasClass(settings.template.replace('.', ''));
+				    }),
+                    add_elm = $(wrapper).find(settings.add);
+
+				for (var i = rows.length; i < settings.minimum; i++)
+				    add_elm.click();
+
 
 				refresh(container);
 			});

--- a/repeatable-fields.js
+++ b/repeatable-fields.js
@@ -16,12 +16,16 @@
 			remove: '.remove',
 			move: '.move',
 			template: '.template',
+			minimum: 0,
+			data_prefix: "template",
 			is_sortable: true,
 			before_add: null,
 			after_add: after_add,
 			before_remove: null,
 			after_remove: null,
 			sortable_options: null,
+            reset_inputs: true,
+			row_count_placeholder: "{{row-count-placeholder}}",
 		}
 
 		var settings = $.extend(default_settings, custom_settings);
@@ -33,7 +37,7 @@
 			$(settings.wrapper, parent).each(function(index, element) {
 				var wrapper = this;
 
-				var container = $(wrapper).children(settings.container);
+				var container = $(wrapper).find(settings.container);
 
 				// Disable all form elements inside the row template
 				$(container).children(settings.template).hide().find(':input').each(function() {
@@ -43,11 +47,16 @@
 				$(wrapper).on('click', settings.add, function(event) {
 					event.stopImmediatePropagation();
 
-					var row_template = $($(container).children(settings.template).clone().removeClass(settings.template.replace('.', ''))[0].outerHTML);
+					var row_template = $($(container).children(settings.template).first().clone().removeClass(settings.template.replace('.', ''))[0].outerHTML);
 
 					// Enable all form elements inside the row template
 					jQuery(row_template).find(':input').each(function() {
-						jQuery(this).prop('disabled', false);
+					     jQuery(this).prop('disabled', false);
+					}).not("button").each(function(){
+					    if (settings.reset_inputs){
+					        var input = $(this);
+                            input.prop("checked", input.prop("defaultChecked")).prop("selectedIndex", input.prop("defaultSelected ")).val("");
+					    }
 					});
 
 					if(typeof settings.before_add === 'function') {
@@ -57,8 +66,9 @@
 					var new_row = $(row_template).show().appendTo(container);
 
 					if(typeof settings.after_add === 'function') {
-						settings.after_add(container, new_row);
+					    settings.after_add(container, new_row);
 					}
+					refresh(container);
 
 					// The new row might have it's own repeatable field wrappers so initialize them too
 					initialize(new_row);
@@ -76,30 +86,76 @@
 					row.remove();
 
 					if(typeof settings.after_remove === 'function') {
-						settings.after_remove(container);
+					    settings.after_remove(container);
 					}
+					refresh(container);
 				});
 
 				if(settings.is_sortable === true && typeof $.ui !== 'undefined' && typeof $.ui.sortable !== 'undefined') {
 					var sortable_options = settings.sortable_options !== null ? settings.sortable_options : {};
 
+					var userUpdateEvent = function () { }
+
+					if (sortable_options.hasOwnProperty("update")) {
+					    userUpdateEvent = sortable_options.update;
+					}
+
+					sortable_options.update = function (ev, ui) {
+					    if (typeof userUpdateEvent === 'function') userUpdateEvent(ev, ui);
+
+					    refresh(container);
+					}
 					sortable_options.handle = settings.move;
 
 					$(wrapper).find(settings.container).sortable(sortable_options);
 				}
+
+				refresh(container);
 			});
 		}
 
 		function after_add(container, new_row) {
-			var row_count = $(container).children(settings.row).filter(function() {
-				return !jQuery(this).hasClass(settings.template.replace('.', ''));
-			}).length;
+		    var placeholderRegEx = new RegExp(settings.row_count_placeholder),
+                row_count = $(container).children(settings.row).filter(function () {
+				    return !jQuery(this).hasClass(settings.template.replace('.', ''));
+			    }).length;
 
-			$('*', new_row).each(function() {
-				$.each(this.attributes, function(index, element) {
-					this.value = this.value.replace(/{{row-count-placeholder}}/, row_count - 1);
-				});
+			$('*', new_row).each(function () {
+			    $.each(this.attributes, function (index, element) {
+			        if (this.name.slice(0, "data-template-".length) != "data-template-")
+			            this.value = this.value.replace(placeholderRegEx, row_count - 1);
+			    });
 			});
+		}
+
+		function refresh(container) {
+		    var dataRegEx = new RegExp("^" + settings.data_prefix + "((?:[A-Z][a-z0-1]*)+)$"),
+		        placeholderRegEx = new RegExp(settings.row_count_placeholder),
+		        row_index = 0;
+
+		    $(container).children(settings.row).filter(function() {
+		        return !jQuery(this).hasClass(settings.template.replace('.', ''));
+		    }).each(function (i, elm) {
+		        if (row_index < settings.minimum) {
+		            $(this).find(settings.remove).prop("disabled", true).addClass("disabled");
+		        } else {
+		            $(this).find(settings.remove).prop("disabled", false).removeClass("disabled");
+		        }
+		        
+
+		        $('*', this).each(function () {
+		            var self = $(this),
+                        dataAttrs = self.data();
+
+		            for (i in dataAttrs) {
+		                if (dataRegEx.test(i)) {
+		                    self.attr(dataRegEx.exec(i)[1].toLowerCase(), dataAttrs[i].replace(placeholderRegEx, row_index));
+		                }
+		            }
+		        });
+
+		        row_index++;
+		    })
 		}
 	}
 })(jQuery);


### PR DESCRIPTION
I have added the ability to have data attribute based templates to the template row, which then have their row-count-placeholder values updated when a row is moved.

I have also added a few other options. The `row_count_placeholder` option allows to customize the placeholder replace string. I have updated the README to describe how to use the new features.

Everything is backwards compatible, and there should be no breaking changes, as all options have sane defaults. The only option that _may_ be a breaking change is the `reset_inputs` option, which is true by default and resets/clears all input values when a row is added. This is normally what you'd want anyway, but this can be false by default if you prefer.

data attribute based templating works by setting data attributes on elements within the template row. An attribute can be: `data-template-name` where "template" is from the `data_prefix` option ("template" by default) and "name" is the attribute it is templating. This allows the row count to be updated for that templated attribute when the row is moved. If that attribute already exists, the template attribute will override it. So, if you want an attribute to update the row index when it is moved (like an order field) then use the template, otherwise use the usual attribute, which is only updated on adding it.

The `minimum` option is used to specify a minimum number of rows, which are created on initialization if the number of rows don't equal the minimum already. The remove elements are disabled for the first minimum number of rows also, helping to enforcing the minimum.

I haven't updated the version number, assuming you would want to do this to your liking.

I think that is everything, I am using my updated version in a project I am working on, so it's pretty well tested. If you have any questions or issues I can get back to you. Thanks for this great plugin.