### PR TITLE
jQuery to $ inside the plugin

### DIFF
--- a/repeatable-fields.js
+++ b/repeatable-fields.js
@@ -37,7 +37,7 @@
 
 				// Disable all form elements inside the row template
 				$(container).children(settings.template).hide().find(':input').each(function() {
-					jQuery(this).prop('disabled', true);
+					$(this).prop('disabled', true);
 				});
 
 				$(wrapper).on('click', settings.add, function(event) {
@@ -46,8 +46,8 @@
 					var row_template = $($(container).children(settings.template).clone().removeClass(settings.template.replace('.', ''))[0].outerHTML);
 
 					// Enable all form elements inside the row template
-					jQuery(row_template).find(':input').each(function() {
-						jQuery(this).prop('disabled', false);
+					$(row_template).find(':input').each(function() {
+						$(this).prop('disabled', false);
 					});
 
 					if(typeof settings.before_add === 'function') {
@@ -92,7 +92,7 @@
 
 		function after_add(container, new_row) {
 			var row_count = $(container).children(settings.row).filter(function() {
-				return !jQuery(this).hasClass(settings.template.replace('.', ''));
+				return !$(this).hasClass(settings.template.replace('.', ''));
 			}).length;
 
 			$('*', new_row).each(function() {


### PR DESCRIPTION
Without this change, the following userscript fails:

```javascript
// ==UserScript==
// @name  Monkeys script dependency
// @match https://github.com/
// @require http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.js
// @require http://rawgit.com/brasofilo/repeatable-fields/master/repeatable-fields.js
// @grant none
// ==/UserScript==
start_up();
function start_up () {
    var FULL_table_html = '<table>etc</table>';
    $('.wrapper').prepend(FULL_table_html);
	$('.repeat').each(function() {
        $(this).repeatable_fields();
    });
}
```