### PR TITLE
Bower dependencies not resolved

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,10 +7,7 @@
 	],
 	"dependencies": {
 		"jquery": ">=1.9.0",
-		"jquery-ui.ui.core": ">=1.10.3",
-		"jquery-ui.ui.widget": ">=1.10.3",
-		"jquery-ui.ui.mouse": ">=1.10.3",
-		"jquery-ui.ui.sortable": ">=1.10.3"
+		"jquery-ui": ">=1.10.3"
 	},
 	"keywords": [
 		"repeatable-fields",

--- a/bower.json
+++ b/bower.json
@@ -6,10 +6,10 @@
 	],
 	"dependencies": {
 		"jquery": ">=1.9.0",
-		"ui.core": ">=1.10.3",
-		"ui.widget": ">=1.10.3",
-		"ui.mouse": ">=1.10.3",
-		"ui.sortable": ">=1.10.3"
+		"jquery.ui.core": ">=1.10.3",
+		"jquery.ui.widget": ">=1.10.3",
+		"jquery.ui.mouse": ">=1.10.3",
+		"jquery.ui.sortable": ">=1.10.3"
 	},
 	"keywords": [
 		"repeatable-fields",

--- a/bower.json
+++ b/bower.json
@@ -7,10 +7,10 @@
 	],
 	"dependencies": {
 		"jquery": ">=1.9.0",
-		"jquery.ui.core": ">=1.10.3",
-		"jquery.ui.widget": ">=1.10.3",
-		"jquery.ui.mouse": ">=1.10.3",
-		"jquery.ui.sortable": ">=1.10.3"
+		"jquery-ui.ui.core": ">=1.10.3",
+		"jquery-ui.ui.widget": ">=1.10.3",
+		"jquery-ui.ui.mouse": ">=1.10.3",
+		"jquery-ui.ui.sortable": ">=1.10.3"
 	},
 	"keywords": [
 		"repeatable-fields",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
 	"name": "repeatable-fields",
 	"description": "Repeatable Fields is a jQuery plugin which let's you create a set of fields that can be made to repeat.",
+	"version": "1.4.1",
 	"main": [
 		"repeatable-fields.js"
 	],


### PR DESCRIPTION
The dependencies to jQuery UI are not resolved by bower. There needs to be a dependency to the jQuery UI repository. The end-user is then free to include the scripts either:

- one by one (sortable, widget, core, ...)
- the whole jQuery UI script

